### PR TITLE
Update publications and profile

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ toc: false
 # Hagai Rossman
 
 ::: {.profile-title}
-Affiliated Assistant Professor of Personalized Medicine
+Assistant Professor of Personalized Medicine
 :::
 
 ::: {.profile-affiliation}

--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ toc: false
 # Hagai Rossman
 
 ::: {.profile-title}
-Assistant Professor of Personalized Medicine
+Affiliated Assistant Professor of Personalized Medicine
 :::
 
 ::: {.profile-affiliation}
@@ -29,10 +29,11 @@ Chief Scientist, Pheno.AI
 
 I develop data-driven computational systems that transform rich biomedical data into actionable health insights. My work integrates data-driven computational modeling and AI methods with clinical knowledge to model disease trajectories and support personalized health interventions in real-world settings.
 
+I am a co-founder of the Human Phenotype Project, a large-scale deep phenotyping cohort integrating multi-omics, imaging, wearables, and lifestyle data.
+
 My research agenda focuses on three interconnected themes: foundation models that learn generalizable representations from multimodal health data; knowledge-infused approaches that ground predictions in biomedical and clinical understanding; and compound AI systems that combine specialized models, agents, and large language models to support complex clinical reasoning and decision making.
 
-I completed my PhD at the [Segal Lab](https://genie.weizmann.ac.il/) at the Weizmann Institute of Science, where I played a central role in establishing and scaling the [Human Phenotype Project (HPP)](https://www.nature.com/articles/s41591-025-03790-9), a large-scale deep phenotyping cohort. My work spanned both the scientific and infrastructural foundations of the project, including the development of predictive models from nationwide electronic health records and high-dimensional phenotypic data.
-
+I earned my PhD in Computer Science at the Weizmann Institute of Science, where I played a central role in establishing and scaling the [Human Phenotype Project (HPP)](https://www.nature.com/articles/s41591-025-03790-9) and developing predictive models from nationwide electronic health records and high-dimensional phenotypic data.
 
 ---
 
@@ -40,14 +41,14 @@ I completed my PhD at the [Segal Lab](https://genie.weizmann.ac.il/) at the Weiz
 
 **[A foundation model for continuous glucose monitoring data](https://www.nature.com/articles/s41586-025-09925-9)**
 A transformer-based foundation model trained on 10 million glucose measurements that generalizes across populations and predicts diverse health outcomes.
-*Nature, 2025*
+*Nature, 2026*
 
-**[Deep phenotyping of health-disease continuum in the Human Phenotype Project](https://www.nature.com/articles/s41591-025-03790-9)**
-Comprehensive deep phenotyping of 36,000 individuals reveals interconnected health dimensions and enables data-driven disease prediction across the health-disease continuum.
-*Nature Medicine, 2025*
+**[Diet-microbiome associations in 10,068 individuals from the Human Phenotype Project to guide personalized nutrition](https://www.nature.com/articles/s41591-026-04312-x)**
+A large-scale HPP analysis linking dietary patterns and gut microbiome composition to support personalized nutrition.
+*Nature Medicine, 2026*
 
-**[Axes of a revolution: challenges and promises of big data in healthcare](https://www.nature.com/articles/s41591-019-0727-5)**
-A perspective on how big data and AI are transforming healthcare through personalized medicine, while addressing key challenges in data integration and clinical translation.
-*Nature Medicine, 2020*
+**[Simulating clinical interventions with a generative multimodal model of human physiology](https://arxiv.org/abs/2604.27899)**
+A generative model of human physiology trained on longitudinal multimodal HPP data to simulate clinical interventions and health trajectories.
+*arXiv, 2026*
 
 [View all publications](publications.md)

--- a/other.md
+++ b/other.md
@@ -4,6 +4,8 @@ title: "Other"
 
 ## Invited Talks
 
+- **[Machines Can Think Summit](https://machinescanthink.ai/)**, Abu Dhabi - "The Human Phenotype Project: Personalized Medicine Based on Deep Human Phenotyping", January 2026
+
 - **The Israel National Institute for Health Policy Research** - Modelists Seminar, February 2022
 
 - **[NATO Operations Research & Analysis Conference](https://events.sto.nato.int/index.php/upcoming-events/event-list/event/28-conf/350-15th-nato-ora-conference)** - Keynote Speaker, October 2021
@@ -19,6 +21,12 @@ title: "Other"
 - **[Life Science Alliance - AI in Healthcare Symposium](https://med.stanford.edu/lifesciencealliance/symposium.html)**, Heilbronn - "Rapid Deployment of a Nationwide Symptoms Survey During the Outbreak and Spread of COVID-19", October 2020
 
 - **[NBER - Machine Learning in Health Care](https://www.nber.org/conferences/machine-learning-health-care-spring-2019)**, Boston - "Childhood Obesity Prediction and Risk Factor Analysis from Nationwide Health Records", May 2019
+
+---
+
+## Academic Activities
+
+- Helped organize **[HPP Global 2026: From Deep-Phenotype Data to Personalized Medicine](https://natureconferences.streamgo.live/phenotype/agenda)**, February 2026
 
 ---
 

--- a/publications.md
+++ b/publications.md
@@ -6,138 +6,166 @@ Full list at [Google Scholar](https://scholar.google.com/citations?user=kQrQJ1gA
 
 ---
 
+## 2026
+
+**[Heterogeneity of Insulin Resistance Surrogates in Thousands of Non-Diabetic Adults: Multi-Modal Data Reveals Discordant Metabolic Phenotypes](https://www.medrxiv.org/content/10.64898/2026.05.02.26352290v1)**\
+Smadar Shilo, Yeela Talmor-Barkan, Maria Gorodetski, Dana Azouri, Anastasia Godneva, Eran Segal, Hagai Rossman.\
+*medRxiv* [[preprint](https://www.medrxiv.org/content/10.64898/2026.05.02.26352290v1)] [[code](https://github.com/hrossman/hpp-insulin-resistance-paper-public)]
+
+**[Simulating clinical interventions with a generative multimodal model of human physiology](https://arxiv.org/abs/2604.27899)**\
+Guy Lutsker, Gal Sapir, Jordi Merino, Smadar Shilo, Anastasia Godneva, Eli Meirom, Shie Mannor, Hagai Rossman, Gal Chechik, Eran Segal.\
+*arXiv* [[preprint](https://arxiv.org/abs/2604.27899)]
+
+**[Diet-microbiome associations in 10,068 individuals from the Human Phenotype Project to guide personalized nutrition](https://www.nature.com/articles/s41591-026-04312-x)**\
+Tomer Segev, Daniel Barak, Liron Zahavi, Anastasia Godneva, Michal Rein, David Krongauz, Dorit Samocha-Bonet, Hagai Rossman, Adina Weinberger, Eran Segal.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-026-04312-x)] [[preprint](https://www.medrxiv.org/content/10.1101/2025.10.12.25337559)] [[code](https://github.com/TmrSegev/diet-microbiome)]
+
+**[Day-to-day dietary variation shapes overnight sleep physiology: a target-trial emulation in 4.8 thousand person-nights](https://www.medrxiv.org/content/10.64898/2026.02.17.26346471v1)**\
+Mariya Shkolnik, Gal Sapir, Smadar Shilo, Yeela Talmor-Barkan, Eran Segal, Hagai Rossman.\
+*medRxiv* [[preprint](https://www.medrxiv.org/content/10.64898/2026.02.17.26346471v1)] [[code](https://github.com/mashaashkolnik/causal_framework)]
+
+**[A foundation model for continuous glucose monitoring data](https://www.nature.com/articles/s41586-025-09925-9)**\
+Guy Lutsker, Gal Sapir, Smadar Shilo, Jordi Merino, Anastasia Godneva, Jerry R. Greenfield, Dorit Samocha-Bonet, Raja Dhir, Francisco Gude, Shie Mannor, Eli Meirom, Eric P. Xing, Gal Chechik, Hagai Rossman, Eran Segal.\
+*Nature* [[paper](https://www.nature.com/articles/s41586-025-09925-9)] [[code](https://github.com/Guylu/GluFormer)]
+
+
 ## 2025
 
-**Deep phenotyping of health-disease continuum in the Human Phenotype Project**\
-Lee Reicher, Smadar Shilo, Anastasia Godneva, et al.\
-*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-025-03790-9)]
+**[0054 The Human Phenotype Project: Metabolomic Signatures of Sleep Characteristics Reveal Gender-Specific Insights](https://academic.oup.com/sleep/article/48/Supplement_1/A24/8136049)**\
+Sarah Kohn, Alon Diament, Anastasia Godneva, Raja Dhir, Adina Weinberger, Yotam Reisner, Hagai Rossman, Eran Segal.\
+*SLEEP* [[abstract](https://academic.oup.com/sleep/article/48/Supplement_1/A24/8136049)]
 
-**Phenome-wide associations of sleep characteristics in the Human Phenotype Project**\
+**[Delta ECG: A Genetic Perspective](https://iclr.cc/virtual/2025/35993)**\
+Zachary Levine, Hagai Rossman, Eran Segal.\
+*ICLR 2025 Learning Meaningful Representations of Life Workshop* [[workshop page](https://iclr.cc/virtual/2025/35993)] [[openreview](https://openreview.net/forum?id=3DWk04CQzb)]
+
+**[Phenome-wide associations of sleep characteristics in the Human Phenotype Project](https://www.nature.com/articles/s41591-024-03481-x)**\
 Sarah Kohn, Alon Diament, Anastasia Godneva, Raja Dhir, Adina Weinberger, Yotam Reisner, Hagai Rossman, Eran Segal.\
 *Nature Medicine* [[paper](https://www.nature.com/articles/s41591-024-03481-x)]
 
-**Multimodal AI correlates of glucose spikes in people with normal glucose regulation, pre-diabetes and type 2 diabetes**\
+**[Multimodal AI correlates of glucose spikes in people with normal glucose regulation, pre-diabetes and type 2 diabetes](https://www.nature.com/articles/s41591-025-03849-7)**\
 Mattia Carletti, Jay Pandit, Matteo Gadaleta, et al.\
 *Nature Medicine* [[paper](https://www.nature.com/articles/s41591-025-03849-7)]
 
-**Diet shapes the gut microbiome: cross-sectional and longitudinal insights from the Human Phenotype Project**\
-Tomer Segev, Daniel Barak, Liron Zahavi, Anastasia Godneva, Michal Rein, David Krongauz, Hagai Rossman, Adina Weinberger, Eran Segal.\
-*medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2025.10.12.25337559)]
+**[Deep phenotyping of health-disease continuum in the Human Phenotype Project](https://www.nature.com/articles/s41591-025-03790-9)**\
+Lee Reicher, Smadar Shilo, Anastasia Godneva, et al.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-025-03790-9)]
 
-**A foundation model for continuous glucose monitoring data**\
-Guy Lutsker, Gal Sapir, Anastasia Godneva, Smadar Shilo, et al.\
-*Nature* [[paper](https://www.nature.com/articles/s41586-025-09925-9)]
 
 ## 2024
 
-**COMPRER: A Multimodal Foundation Model for Cardiovascular Imaging**\
-Guy Lutsker, Hagai Rossman, Nastya Godneva, Eran Segal.\
-*medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2024.03.17.24304415v2)]
-
-**Continuous glucose monitoring and intrapersonal variability in fasting glucose**\
-Smadar Shilo, Ayya Keshet, Hagai Rossman, Anastasia Godneva, Yeela Talmor-Barkan, Yaron Aviv, Eran Segal.\
-*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-024-02908-9)]
-
-**Genome-wide association studies and polygenic risk score phenome-wide association studies across complex phenotypes in the Human Phenotype Project**\
-Zachary Levine, Iris Kalka, Dmitry Kolobkov, Hagai Rossman, et al.\
-*Med* [[paper](https://www.cell.com/med/abstract/S2666-6340(23)00400-2)]
-
-**Unveiling associations between retinal microvascular architecture and phenotypes across thousands of healthy subjects**\
+**[Unveiling associations between retinal microvascular architecture and phenotypes across thousands of healthy subjects](https://www.medrxiv.org/content/10.1101/2024.04.05.24305164)**\
 Michal Shapira, Smadar Shilo, Yeela Talmor-Barkan, et al.\
 *medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2024.04.05.24305164)]
 
+**[Genome-wide association studies and polygenic risk score phenome-wide association studies across complex phenotypes in the Human Phenotype Project](https://www.cell.com/med/abstract/S2666-6340(23)00400-2)**\
+Zachary Levine, Iris Kalka, Dmitry Kolobkov, Hagai Rossman, et al.\
+*Med* [[paper](https://www.cell.com/med/abstract/S2666-6340(23)00400-2)]
+
+**[Continuous glucose monitoring and intrapersonal variability in fasting glucose](https://www.nature.com/articles/s41591-024-02908-9)**\
+Smadar Shilo, Ayya Keshet, Hagai Rossman, Anastasia Godneva, Yeela Talmor-Barkan, Yaron Aviv, Eran Segal.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-024-02908-9)]
+
+**[COMPRER: A Multimodal Foundation Model for Cardiovascular Imaging](https://www.medrxiv.org/content/10.1101/2024.03.17.24304415v2)**\
+Guy Lutsker, Hagai Rossman, Nastya Godneva, Eran Segal.\
+*medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2024.03.17.24304415v2)]
+
+
 ## 2023
 
-**CGMap: Characterizing continuous glucose monitor data in thousands of non-diabetic individuals**\
-Ayya Keshet, Smadar Shilo, Anastasia Godneva, Yeela Talmor-Barkan, Yaron Aviv, Eran Segal, Hagai Rossman.\
-*Cell Metabolism* [[paper](https://www.cell.com/cell-metabolism/pdf/S1550-4131(23)00129-8.pdf)]
-
-**Head-to-head efficacy and safety of rivaroxaban, apixaban, and dabigatran in an observational nationwide targeted trial**\
+**[Head-to-head efficacy and safety of rivaroxaban, apixaban, and dabigatran in an observational nationwide targeted trial](https://academic.oup.com/ehjcvp/article/9/1/26/6807409)**\
 Yeela Talmor-Barkan, Nancy-Sarah Yacovzada, Hagai Rossman, Guy Witberg, Iris Kalka, Ran Kornowski, Eran Segal.\
 *European Heart Journal - Cardiovascular Pharmacotherapy* [[paper](https://academic.oup.com/ehjcvp/article/9/1/26/6807409)]
 
-**A Multimodal Dataset of 21,412 Recorded Nights for Sleep and Respiratory Research**\
+**[CGMap: Characterizing continuous glucose monitor data in thousands of non-diabetic individuals](https://www.cell.com/cell-metabolism/pdf/S1550-4131(23)00129-8.pdf)**\
+Ayya Keshet, Smadar Shilo, Anastasia Godneva, Yeela Talmor-Barkan, Yaron Aviv, Eran Segal, Hagai Rossman.\
+*Cell Metabolism* [[paper](https://www.cell.com/cell-metabolism/pdf/S1550-4131(23)00129-8.pdf)]
+
+**[A Multimodal Dataset of 21,412 Recorded Nights for Sleep and Respiratory Research](https://arxiv.org/abs/2311.08979)**\
 Alon Diament, Maria Gorodetski, Adam Jankelow, Ayya Keshet, Tal Shor, Daphna Weissglas-Volkov, Hagai Rossman, Eran Segal.\
 *NeurIPS ML4H Workshop* [[paper](https://arxiv.org/abs/2311.08979)]
 
+
 ## 2022
 
-**PyMSM: Python package for Competing Risks and Multi-State models for Survival Data**\
-Hagai Rossman, Ayya Keshet, Malka Gorfine.\
-*JOSS* [[paper](https://joss.theoj.org/papers/10.21105/joss.04566)] [[code](https://github.com/hrossman/pymsm)]
-
-**The role of models in the covid-19 pandemic**\
+**[The role of models in the covid-19 pandemic](https://ijhpr.biomedcentral.com/articles/10.1186/s13584-022-00546-5)**\
 David M. Steinberg, Ran D. Balicer, Yoav Benjamini, Hilla De-Leon, Doron Gazit, Hagai Rossman, Eli Sprecher.\
 *Israel Journal of Health Policy Research* [[paper](https://ijhpr.biomedcentral.com/articles/10.1186/s13584-022-00546-5)]
 
-**Estimating the effect of cesarean delivery on long-term childhood health across two countries**\
+**[PyMSM: Python package for Competing Risks and Multi-State models for Survival Data](https://joss.theoj.org/papers/10.21105/joss.04566)**\
+Hagai Rossman, Ayya Keshet, Malka Gorfine.\
+*JOSS* [[paper](https://joss.theoj.org/papers/10.21105/joss.04566)] [[code](https://github.com/hrossman/pymsm)]
+
+**[Estimating the effect of cesarean delivery on long-term childhood health across two countries](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0268103)**\
 Ayya Keshet, Hagai Rossman, Smadar Shilo, et al.\
 *PLOS ONE* [[paper](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0268103)] [[code](https://github.com/ayya-keshet/Causal-Survival-Analysis)]
 
+
 ## 2021
 
-**COVID-19 dynamics after a national immunization program in Israel**\
-Hagai Rossman, Smadar Shilo, Tomer Meir, Malka Gorfine, Uri Shalit, Eran Segal.\
-*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-021-01337-2)] [[press: Economist](https://www.economist.com/briefing/2021/02/13/when-covid-19-vaccines-meet-the-new-variants-of-the-virus)] [[press: Financial Times](https://www.ft.com/content/0cdc8563-1e6d-4089-bedb-b0f675c0d683)]
-
-**Hospital load and increased COVID-19 related mortality in Israel**\
-Hagai Rossman, Tomer Meir, Jonathan Somer, Smadar Shilo, Rom Gutman, Asaf Ben-Arie, Eran Segal, Uri Shalit, Malka Gorfine.\
-*Nature Communications* [[paper](https://www.nature.com/articles/s41467-021-22214-z)] [[code](https://github.com/tomer1812/covid19-israel-multi-state-hospitalization-model)]
-
-**Prediction of childhood obesity from nationwide health records**\
-Hagai Rossman, Smadar Shilo, Shiri Hazan, Nitzan Artzi, Eran Hadar, Ran Balicer, Becca Feldman, Arnon Wiznitzer, Eran Segal.\
-*Journal of Pediatrics* [[paper](https://www.jpeds.com/article/S0022-3476(21)00119-0/)]
-
-**Nowcasting the spread of SARS-CoV-2**\
-Hagai Rossman, Eran Segal.\
-*Nature Microbiology* [[paper](https://www.nature.com/articles/s41564-021-01035-2)]
-
-**Signals of hope: Gauging the impact of a rapid national vaccination campaign**\
-Smadar Shilo, Hagai Rossman, Eran Segal.\
-*Nature Reviews Immunology* [[paper](https://www.nature.com/articles/s41577-021-00531-0)]
-
-**Cohort profile: 10K - a large-scale prospective longitudinal study in Israel**\
-Smadar Shilo, Noam Bar, Ayya Keshet, et al.\
-*European Journal of Epidemiology* [[paper](https://link.springer.com/article/10.1007/s10654-021-00753-5)]
-
-**Stress-related emotional and behavioural impact following the first COVID-19 outbreak peak**\
+**[Stress-related emotional and behavioural impact following the first COVID-19 outbreak peak](https://www.nature.com/articles/s41380-021-01219-6)**\
 Asaf Benjamin, Yael Kuperman, Noa Eren, et al.\
 *Molecular Psychiatry* [[paper](https://www.nature.com/articles/s41380-021-01219-6)]
 
-**Anosmia, ageusia, and other COVID-19-like symptoms in association with a positive SARS-CoV-2 test**\
-Carole H Sudre, Ayya Keshet, et al.\
-*Lancet Digital Health* [[paper](https://www.thelancet.com/journals/landig/article/PIIS2589-7500(21)00115-1/fulltext)]
+**[Signals of hope: Gauging the impact of a rapid national vaccination campaign](https://www.nature.com/articles/s41577-021-00531-0)**\
+Smadar Shilo, Hagai Rossman, Eran Segal.\
+*Nature Reviews Immunology* [[paper](https://www.nature.com/articles/s41577-021-00531-0)]
 
-**Estimating heritability of glycaemic response to metformin using nationwide electronic health records and population-sized pedigree**\
+**[Prediction of childhood obesity from nationwide health records](https://www.jpeds.com/article/S0022-3476(21)00119-0/)**\
+Hagai Rossman, Smadar Shilo, Shiri Hazan, Nitzan Artzi, Eran Hadar, Ran Balicer, Becca Feldman, Arnon Wiznitzer, Eran Segal.\
+*Journal of Pediatrics* [[paper](https://www.jpeds.com/article/S0022-3476(21)00119-0/)]
+
+**[Nowcasting the spread of SARS-CoV-2](https://www.nature.com/articles/s41564-021-01035-2)**\
+Hagai Rossman, Eran Segal.\
+*Nature Microbiology* [[paper](https://www.nature.com/articles/s41564-021-01035-2)]
+
+**[Hospital load and increased COVID-19 related mortality in Israel](https://www.nature.com/articles/s41467-021-22214-z)**\
+Hagai Rossman, Tomer Meir, Jonathan Somer, Smadar Shilo, Rom Gutman, Asaf Ben-Arie, Eran Segal, Uri Shalit, Malka Gorfine.\
+*Nature Communications* [[paper](https://www.nature.com/articles/s41467-021-22214-z)] [[code](https://github.com/tomer1812/covid19-israel-multi-state-hospitalization-model)]
+
+**[Estimating heritability of glycaemic response to metformin using nationwide electronic health records and population-sized pedigree](https://www.nature.com/articles/s43856-021-00058-4)**\
 Iris Kalka, Amir Gavrieli, Smadar Shilo, Hagai Rossman, Nitzan Artzi, Nancy-Sarah Yacovzada, Eran Segal.\
 *Communications Medicine* [[paper](https://www.nature.com/articles/s43856-021-00058-4)]
 
-**A prediction model to prioritize individuals for a SARS-CoV-2 test built from national symptom surveys**\
+**[Cohort profile: 10K - a large-scale prospective longitudinal study in Israel](https://link.springer.com/article/10.1007/s10654-021-00753-5)**\
+Smadar Shilo, Noam Bar, Ayya Keshet, et al.\
+*European Journal of Epidemiology* [[paper](https://link.springer.com/article/10.1007/s10654-021-00753-5)]
+
+**[COVID-19 dynamics after a national immunization program in Israel](https://www.nature.com/articles/s41591-021-01337-2)**\
+Hagai Rossman, Smadar Shilo, Tomer Meir, Malka Gorfine, Uri Shalit, Eran Segal.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-021-01337-2)] [[press economist](https://www.economist.com/briefing/2021/02/13/when-covid-19-vaccines-meet-the-new-variants-of-the-virus)] [[press financial times](https://www.ft.com/content/0cdc8563-1e6d-4089-bedb-b0f675c0d683)]
+
+**[Anosmia, ageusia, and other COVID-19-like symptoms in association with a positive SARS-CoV-2 test](https://www.thelancet.com/journals/landig/article/PIIS2589-7500(21)00115-1/fulltext)**\
+Carole H Sudre, Ayya Keshet, et al.\
+*Lancet Digital Health* [[paper](https://www.thelancet.com/journals/landig/article/PIIS2589-7500(21)00115-1/fulltext)]
+
+**[A prediction model to prioritize individuals for a SARS-CoV-2 test built from national symptom surveys](https://www.cell.com/med/fulltext/S2666-6340(20)30019-2)**\
 Saar Shoer, Tal Karady, Ayya Keshet, Smadar Shilo, Hagai Rossman, et al.\
 *Med* [[paper](https://www.cell.com/med/fulltext/S2666-6340(20)30019-2)]
 
+
 ## 2020
 
-**A framework for identifying regional outbreak and spread of COVID-19 from one-minute population-wide surveys**\
-Hagai Rossman, Ayya Keshet, Smadar Shilo, et al.\
-*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-020-0857-9)]
+**[The effect of a national lockdown in response to COVID-19 pandemic on the prevalence of clinical symptoms in the population](https://www.medrxiv.org/content/10.1101/2020.04.27.20076000v2)**\
+Ayya Keshet, Amir Gavrieli, Hagai Rossman, et al.\
+*medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2020.04.27.20076000v2)]
 
-**Longitudinal symptom dynamics of COVID-19 infection**\
-Barak Mizrahi, Smadar Shilo, Hagai Rossman, et al.\
-*Nature Communications* [[paper](https://www.nature.com/articles/s41467-020-20053-y)]
-
-**Building an International Consortium for Tracking Coronavirus Health Status**\
-Segal et al.\
-*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-020-0929-x)]
-
-**Prediction of gestational diabetes based on nationwide electronic health records**\
+**[Prediction of gestational diabetes based on nationwide electronic health records](https://www.nature.com/articles/s41591-019-0724-8)**\
 Nitzan Artzi, Smadar Shilo, Eran Hadar, Hagai Rossman, et al.\
 *Nature Medicine* [[paper](https://www.nature.com/articles/s41591-019-0724-8)]
 
-**Axes of a revolution: challenges and promises of big data in healthcare**\
+**[Longitudinal symptom dynamics of COVID-19 infection](https://www.nature.com/articles/s41467-020-20053-y)**\
+Barak Mizrahi, Smadar Shilo, Hagai Rossman, et al.\
+*Nature Communications* [[paper](https://www.nature.com/articles/s41467-020-20053-y)]
+
+**[Building an International Consortium for Tracking Coronavirus Health Status](https://www.nature.com/articles/s41591-020-0929-x)**\
+Segal et al.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-020-0929-x)]
+
+**[Axes of a revolution: challenges and promises of big data in healthcare](https://www.nature.com/articles/s41591-019-0727-5)**\
 Smadar Shilo, Hagai Rossman, Eran Segal.\
 *Nature Medicine* [[paper](https://www.nature.com/articles/s41591-019-0727-5)]
 
-**The effect of a national lockdown in response to COVID-19 pandemic on the prevalence of clinical symptoms in the population**\
-Ayya Keshet, Amir Gavrieli, Hagai Rossman, et al.\
-*medRxiv preprint* [[paper](https://www.medrxiv.org/content/10.1101/2020.04.27.20076000v2)]
+**[A framework for identifying regional outbreak and spread of COVID-19 from one-minute population-wide surveys](https://www.nature.com/articles/s41591-020-0857-9)**\
+Hagai Rossman, Ayya Keshet, Smadar Shilo, et al.\
+*Nature Medicine* [[paper](https://www.nature.com/articles/s41591-020-0857-9)]


### PR DESCRIPTION
## Summary
- update homepage title/profile copy and featured publications
- refresh publications page from the curated assets inventory, including 2026 papers/preprints and 2025 workshop/abstract entries
- add Machines Can Think and HPP Global 2026 to the Other page

## Validation
- quarto render
- browser check of rendered localhost site for homepage and publications page
- git diff --check